### PR TITLE
Fix label validation in save_labeled_image

### DIFF
--- a/card_dealer/recognizer.py
+++ b/card_dealer/recognizer.py
@@ -132,6 +132,10 @@ def save_labeled_image(image_path: Path, label: str) -> Path:
     """
 
     image_path = Path(image_path)
+
+    if "/" in label or "\\" in label:
+        raise ValueError(f"Invalid label: {label}")
+
     DATASET_DIR.mkdir(parents=True, exist_ok=True)
 
     base_name = label.replace(" ", "_")

--- a/tests/test_recognizer.py
+++ b/tests/test_recognizer.py
@@ -1,0 +1,16 @@
+import pytest
+from pathlib import Path
+
+import card_dealer.recognizer as recognizer
+
+
+def test_save_labeled_image_rejects_bad_label(tmp_path, monkeypatch):
+    monkeypatch.setattr(recognizer, "DATASET_DIR", tmp_path / "dataset")
+    img = tmp_path / "img.png"
+    img.write_text("img")
+
+    with pytest.raises(ValueError):
+        recognizer.save_labeled_image(img, "../evil")
+
+    assert not (tmp_path / "evil.png").exists()
+    assert not (tmp_path / "dataset").exists()


### PR DESCRIPTION
## Summary
- prevent saving labeled images with path separators
- add regression test for invalid labels in recognizer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868352ff62883338f89caff74555e00