### PR TITLE
Support multiple templates for recognizer

### DIFF
--- a/card_dealer/recognizer.py
+++ b/card_dealer/recognizer.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import shutil
-from typing import Dict
+from typing import Dict, List
 
 try:  # pragma: no cover - OpenCV/Numpy may not be installed
     import cv2
@@ -27,21 +27,23 @@ DATASET_DIR = Path(__file__).resolve().parent.parent / "dataset"
 
 # Cache for loaded templates so that multiple calls do not repeatedly read the
 # same files from disk.
-_TEMPLATES: Dict[str, "np.ndarray"] | None = None
+_TEMPLATES: Dict[str, List["np.ndarray"]] | None = None
 
 
-def _load_templates() -> Dict[str, "np.ndarray"]:
+def _load_templates() -> Dict[str, List["np.ndarray"]]:
     """Load image templates from :data:`DATASET_DIR`.
 
     The images are expected to be named using the pattern ``"<label>.<ext>"``
-    where ``<label>`` is the card name (e.g. ``"Ace_of_Spades"``).  The
-    function converts each image to grayscale and stores it in a dictionary
-    keyed by the label.
+    where ``<label>`` is the card name (e.g. ``"Ace_of_Spades"``).  When
+    multiple images with the same base name exist, e.g. ``"Ace_of_Spades_1"``,
+    all of them are loaded and stored under the same label.  The function
+    converts each image to grayscale and stores them in a dictionary keyed by
+    the label.
 
     Returns
     -------
     dict
-        Mapping of label to grayscale image arrays.
+        Mapping of label to a list of grayscale image arrays.
     """
 
     global _TEMPLATES
@@ -51,15 +53,17 @@ def _load_templates() -> Dict[str, "np.ndarray"]:
     if cv2 is None:  # pragma: no cover - OpenCV optional
         raise RuntimeError("OpenCV is required for card recognition")
 
-    templates: Dict[str, "np.ndarray"] = {}
+    templates: Dict[str, List["np.ndarray"]] = {}
     if DATASET_DIR.exists():
         for img_path in DATASET_DIR.iterdir():
             if not img_path.is_file():
                 continue
-            label = img_path.stem.replace("_", " ")
+            stem = img_path.stem
+            base = stem.rsplit("_", 1)[0] if stem.rsplit("_", 1)[-1].isdigit() else stem
+            label = base.replace("_", " ")
             img = cv2.imread(str(img_path), cv2.IMREAD_GRAYSCALE)
             if img is not None:
-                templates[label] = img
+                templates.setdefault(label, []).append(img)
 
     _TEMPLATES = templates
     return templates
@@ -98,14 +102,15 @@ def recognize_card(image_path: Path) -> str:
 
     best_label = "Unknown"
     best_score = -1.0
-    for label, templ in templates.items():
-        if image.shape[0] < templ.shape[0] or image.shape[1] < templ.shape[1]:
-            continue
-        result = cv2.matchTemplate(image, templ, cv2.TM_CCOEFF_NORMED)
-        _min_val, max_val, _min_loc, _max_loc = cv2.minMaxLoc(result)
-        if max_val > best_score:
-            best_score = max_val
-            best_label = label
+    for label, templ_list in templates.items():
+        for templ in templ_list:
+            if image.shape[0] < templ.shape[0] or image.shape[1] < templ.shape[1]:
+                continue
+            result = cv2.matchTemplate(image, templ, cv2.TM_CCOEFF_NORMED)
+            _min_val, max_val, _min_loc, _max_loc = cv2.minMaxLoc(result)
+            if max_val > best_score:
+                best_score = max_val
+                best_label = label
 
     return best_label
 
@@ -143,7 +148,8 @@ def save_labeled_image(image_path: Path, label: str) -> Path:
         counter += 1
 
     shutil.copy(image_path, dest)
-    # Invalidate template cache so the saved image becomes available immediately
+    # Invalidate template cache so the newly saved image becomes available
+    # immediately and multiple templates per label are reloaded correctly
     global _TEMPLATES
     _TEMPLATES = None
     return dest

--- a/tests/test_recognizer.py
+++ b/tests/test_recognizer.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import card_dealer.recognizer as recognizer
+
+class DummyImage:
+    def __init__(self, ident):
+        self.ident = ident
+        self.shape = (1, 1)
+
+class DummyCV2:
+    IMREAD_GRAYSCALE = 0
+    TM_CCOEFF_NORMED = 1
+
+    def imread(self, path, flag):
+        name = Path(path).name
+        if name == "target.png":
+            return DummyImage("target")
+        elif name.startswith("Ace_of_Hearts"):
+            # two template files
+            if name.endswith("_1.png"):
+                return DummyImage("templ2")
+            return DummyImage("templ1")
+        return None
+
+    def matchTemplate(self, image, templ, method):
+        # templ2 is a better match than templ1
+        score = 0.9 if templ.ident == "templ2" else 0.2
+        return [[score]]
+
+    def minMaxLoc(self, result):
+        val = result[0][0]
+        return 0.0, val, (0, 0), (0, 0)
+
+def test_multiple_templates(monkeypatch, tmp_path):
+    dataset = tmp_path / "dataset"
+    dataset.mkdir()
+    # two files for the same label
+    (dataset / "Ace_of_Hearts.png").write_text("a")
+    (dataset / "Ace_of_Hearts_1.png").write_text("b")
+
+    dummy_cv2 = DummyCV2()
+    monkeypatch.setattr(recognizer, "cv2", dummy_cv2)
+    monkeypatch.setattr(recognizer, "DATASET_DIR", dataset)
+    monkeypatch.setattr(recognizer, "_TEMPLATES", None)
+
+    target = tmp_path / "target.png"
+    target.write_text("img")
+
+    result = recognizer.recognize_card(target)
+
+    templates = recognizer._load_templates()
+
+    assert result == "Ace of Hearts"
+    assert len(templates["Ace of Hearts"]) == 2


### PR DESCRIPTION
## Summary
- support storing multiple template images per label
- iterate through all templates when matching
- ensure cache resets after saving labeled images
- add unit test for multiple templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68683535c5548333ab7738bed8237695