### PR TITLE
Restore label validation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ dataset/                # Captured card images
 templates/              # HTML templates used by the Flask web app
 ```
 
+## Dataset
+
+The ``dataset/`` directory stores labeled reference images used by the simple
+template matcher in :mod:`card_dealer.recognizer`.  File names follow the
+``<rank>_of_<suit>.<ext>`` pattern where ``<ext>`` is typically ``png``.  For
+example a picture of the ace of spades would be saved as
+``dataset/Ace_of_Spades.png``.
+
+
 Most modules are still placeholders.  The :mod:`card_dealer.camera` module can
 capture a single frame from the default camera, and
 :mod:`card_dealer.servo_controller` contains a very small helper used to
@@ -92,4 +101,13 @@ controller.cleanup()
 
 These examples can be executed in a Python REPL after installing the
 dependencies.
+
+## Running tests
+
+The repository contains a small test suite.  After installing the
+dependencies, run `pytest` from the project root to execute the tests:
+
+```bash
+pytest
+```
 

--- a/card_dealer/recognizer.py
+++ b/card_dealer/recognizer.py
@@ -132,6 +132,10 @@ def save_labeled_image(image_path: Path, label: str) -> Path:
     """
 
     image_path = Path(image_path)
+
+    if "/" in label or "\\" in label:
+        raise ValueError(f"Invalid label: {label}")
+
     DATASET_DIR.mkdir(parents=True, exist_ok=True)
 
     base_name = label.replace(" ", "_")

--- a/tests/test_recognizer.py
+++ b/tests/test_recognizer.py
@@ -1,0 +1,16 @@
+import pytest
+from pathlib import Path
+
+import card_dealer.recognizer as recognizer
+
+
+def test_save_labeled_image_rejects_bad_label(tmp_path, monkeypatch):
+    monkeypatch.setattr(recognizer, "DATASET_DIR", tmp_path / "dataset")
+    img = tmp_path / "img.png"
+    img.write_text("img")
+
+    with pytest.raises(ValueError):
+        recognizer.save_labeled_image(img, "../evil")
+
+    assert not (tmp_path / "evil.png").exists()
+    assert not (tmp_path / "dataset").exists()


### PR DESCRIPTION
## Summary
- document dataset naming conventions and pytest usage
- restore `save_labeled_image` label validation
- add regression test for invalid labels

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868354380708333850165970f4a6c77