### PR TITLE
Improve card dataset utilities and training workflow

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+from PIL import Image
+from torch.utils.data import Dataset
+
+
+class CardImageDataset(Dataset):
+    """Dataset that loads card images based on a CSV manifest."""
+
+    def __init__(
+        self,
+        csv_path: str | Path,
+        split: str = "train",
+        *,
+        transform=None,
+        class_to_idx: Optional[dict[str, int]] = None,
+    ) -> None:
+        csv_path = Path(csv_path)
+        df = pd.read_csv(csv_path)
+        df = df[df["data set"] == split].reset_index(drop=True)
+        self.df = df
+        self.transform = transform
+        if class_to_idx is None:
+            class_to_idx = {
+                row["labels"]: int(row["class index"])
+                for _, row in df.drop_duplicates("labels").iterrows()
+            }
+        self.class_to_idx = class_to_idx
+        self.idx_to_class = {v: k for k, v in self.class_to_idx.items()}
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.df)
+
+    def __getitem__(self, idx: int):
+        row = self.df.iloc[idx]
+        path = Path(row["filepaths"])
+        image = Image.open(path).convert("RGB")
+        if self.transform is not None:
+            image = self.transform(image)
+        label = int(row["class index"])
+        return image, label
+
+
+def load_labels(labels_file: Path) -> dict[str, int]:
+    if labels_file.exists():
+        with labels_file.open("r") as f:
+            return json.load(f)
+    return {}
+
+
+def save_labels(labels: dict[str, int], labels_file: Path) -> None:
+    labels_file.parent.mkdir(parents=True, exist_ok=True)
+    with labels_file.open("w") as f:
+        json.dump(labels, f)
+
+

--- a/model.py
+++ b/model.py
@@ -1,32 +1,15 @@
-import torch
+from __future__ import annotations
+
 from torch import nn
+from torchvision.models import resnet18
 
-class CardClassifier(nn.Module):
-    """Simple convolutional network for playing card recognition."""
-    def __init__(self, num_classes: int = 52) -> None:
-        super().__init__()
-        self.features = nn.Sequential(
-            nn.Conv2d(3, 32, kernel_size=3, padding=1),
-            nn.ReLU(inplace=True),
-            nn.MaxPool2d(2),
-            nn.Conv2d(32, 64, kernel_size=3, padding=1),
-            nn.ReLU(inplace=True),
-            nn.MaxPool2d(2),
-            nn.Conv2d(64, 128, kernel_size=3, padding=1),
-            nn.ReLU(inplace=True),
-            nn.MaxPool2d(2),
-        )
-        self.avgpool = nn.AdaptiveAvgPool2d((4, 4))
-        self.classifier = nn.Sequential(
-            nn.Flatten(),
-            nn.Linear(128 * 4 * 4, 256),
-            nn.ReLU(inplace=True),
-            nn.Dropout(0.5),
-            nn.Linear(256, num_classes),
-        )
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = self.features(x)
-        x = self.avgpool(x)
-        x = self.classifier(x)
-        return x
+IMAGE_SIZE = (224, 224)
+
+
+def create_model(num_classes: int) -> nn.Module:
+    """Return a ResNet18 model with custom classification head."""
+    model = resnet18(weights=None)
+    model.fc = nn.Linear(model.fc.in_features, num_classes)
+    return model
+

--- a/train_model.py
+++ b/train_model.py
@@ -1,67 +1,18 @@
+from __future__ import annotations
+
 import argparse
-import json
 from pathlib import Path
-from typing import List, Tuple
 
 import torch
-from torch.utils.data import DataLoader, Dataset
+from torch.utils.data import DataLoader
 from torchvision import transforms
-from PIL import Image
 
-from model import CardClassifier
+from dataset import CardImageDataset
+from model import create_model, IMAGE_SIZE
+from utils import save_checkpoint
 
-IMAGE_SIZE = (100, 150)
 
-class CardDataset(Dataset):
-    def __init__(self, entries: List[Tuple[Path, str]], class_to_idx: dict[str, int], transform=None):
-        self.entries = entries
-        self.class_to_idx = class_to_idx
-        self.transform = transform
-
-    def __len__(self) -> int:
-        return len(self.entries)
-
-    def __getitem__(self, idx: int):
-        path, label = self.entries[idx]
-        image = Image.open(path).convert('RGB')
-        if self.transform is not None:
-            image = self.transform(image)
-        return image, self.class_to_idx[label]
-
-def build_entries(dataset_dir: Path) -> Tuple[List[Tuple[Path, str]], dict[str, int]]:
-    files = [p for p in dataset_dir.iterdir() if p.is_file()]
-    entries: List[Tuple[Path, str]] = []
-    for p in files:
-        stem = p.stem
-        base = stem.rsplit('_', 1)[0] if stem.rsplit('_', 1)[-1].isdigit() else stem
-        label = base.replace('_', ' ')
-        entries.append((p, label))
-    classes = sorted({label for _, label in entries})
-    class_to_idx = {c: i for i, c in enumerate(classes)}
-    return entries, class_to_idx
-
-def split_entries(entries: List[Tuple[Path, str]], val_split: float = 0.1):
-    import random
-    random.shuffle(entries)
-    val_size = int(len(entries) * val_split)
-    return entries[val_size:], entries[:val_size]
-
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Train card recognition model")
-    parser.add_argument('--dataset', default='dataset', help='Path to dataset directory')
-    parser.add_argument('--epochs', type=int, default=10)
-    parser.add_argument('--batch-size', type=int, default=32)
-    parser.add_argument('--model-path', default='model.pt')
-    parser.add_argument('--resume', action='store_true', help='Resume training from existing model')
-    args = parser.parse_args()
-
-    dataset_dir = Path(args.dataset)
-    entries, class_to_idx = build_entries(dataset_dir)
-    if not entries:
-        raise RuntimeError(f'No images found in {dataset_dir}')
-
-    train_entries, val_entries = split_entries(entries)
-
+def build_datasets(csv_path: Path) -> tuple[CardImageDataset, CardImageDataset]:
     train_tf = transforms.Compose([
         transforms.Resize(IMAGE_SIZE),
         transforms.ColorJitter(brightness=0.2, contrast=0.2, saturation=0.2, hue=0.1),
@@ -72,19 +23,24 @@ def main() -> None:
         transforms.Resize(IMAGE_SIZE),
         transforms.ToTensor(),
     ])
+    train_ds = CardImageDataset(csv_path, "train", transform=train_tf)
+    val_ds = CardImageDataset(csv_path, "valid", transform=val_tf, class_to_idx=train_ds.class_to_idx)
+    return train_ds, val_ds
 
-    train_ds = CardDataset(train_entries, class_to_idx, transform=train_tf)
-    val_ds = CardDataset(val_entries, class_to_idx, transform=val_tf)
+
+def train(args: argparse.Namespace) -> None:
+    csv_path = Path(args.csv)
+    train_ds, val_ds = build_datasets(csv_path)
 
     train_loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True)
     val_loader = DataLoader(val_ds, batch_size=args.batch_size)
 
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    model = CardClassifier(num_classes=len(class_to_idx)).to(device)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = create_model(num_classes=len(train_ds.class_to_idx)).to(device)
 
     if args.resume and Path(args.model_path).exists():
         checkpoint = torch.load(args.model_path, map_location=device)
-        state = checkpoint.get('model_state', checkpoint)
+        state = checkpoint.get("model_state", checkpoint)
         try:
             model.load_state_dict(state, strict=False)
         except Exception:
@@ -105,6 +61,7 @@ def main() -> None:
             optimizer.step()
             running_loss += loss.item() * imgs.size(0)
         avg_loss = running_loss / len(train_loader.dataset)
+
         model.eval()
         correct = 0
         with torch.no_grad():
@@ -116,12 +73,20 @@ def main() -> None:
         val_acc = correct / len(val_loader.dataset)
         print(f"Epoch {epoch+1}/{args.epochs} - Loss: {avg_loss:.4f} - Val Acc: {val_acc:.4f}")
 
-    checkpoint = {'model_state': model.state_dict(), 'class_to_idx': class_to_idx}
-    torch.save(checkpoint, args.model_path)
-    labels_path = Path(args.model_path).with_suffix('.json')
-    with labels_path.open('w') as f:
-        json.dump(class_to_idx, f)
+    save_checkpoint(model, train_ds.class_to_idx, Path(args.model_path))
     print(f"Saved model to {args.model_path}")
 
-if __name__ == '__main__':
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train card recognition model")
+    parser.add_argument("--csv", default="cards.csv", help="Path to CSV manifest")
+    parser.add_argument("--epochs", type=int, default=10)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--model-path", default="model.pt")
+    parser.add_argument("--resume", action="store_true", help="Resume from existing model")
+    args = parser.parse_args()
+    train(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
     main()

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pandas as pd
+import torch
+
+
+def save_checkpoint(model: torch.nn.Module, class_to_idx: dict[str, int], out_path: Path) -> None:
+    """Save model weights and label mapping."""
+    checkpoint = {"model_state": model.state_dict(), "class_to_idx": class_to_idx}
+    torch.save(checkpoint, out_path)
+    labels_file = out_path.with_suffix(".json")
+    with labels_file.open("w") as f:
+        json.dump(class_to_idx, f)
+
+
+def load_checkpoint(model_path: Path, device: torch.device | str = "cpu") -> tuple[torch.nn.Module, dict[str, int]]:
+    checkpoint = torch.load(model_path, map_location=device)
+    class_to_idx = checkpoint.get("class_to_idx", {})
+    return checkpoint, class_to_idx
+
+
+def add_new_card(
+    image_path: str | Path,
+    label: str,
+    card_type: str,
+    dataset_split: str = "train",
+    *,
+    data_root: Path = Path("."),
+    csv_file: Path = Path("cards.csv"),
+    labels_file: Path = Path("labels.json"),
+) -> Path:
+    """Copy a new card image and update the dataset manifest."""
+    image_path = Path(image_path)
+    data_dir = data_root / dataset_split / label
+    data_dir.mkdir(parents=True, exist_ok=True)
+    dest = data_dir / image_path.name
+    shutil.copy(image_path, dest)
+
+    if labels_file.exists():
+        with labels_file.open("r") as f:
+            labels = json.load(f)
+    else:
+        labels = {}
+    if label not in labels:
+        labels[label] = max(labels.values(), default=-1) + 1
+        with labels_file.open("w") as f:
+            json.dump(labels, f)
+    class_idx = labels[label]
+
+    if csv_file.exists():
+        df = pd.read_csv(csv_file)
+    else:
+        df = pd.DataFrame(columns=["class index", "filepaths", "labels", "card type", "data set"])
+    new_row = {
+        "class index": class_idx,
+        "filepaths": str(dest),
+        "labels": label,
+        "card type": card_type,
+        "data set": dataset_split,
+    }
+    df = pd.concat([df, pd.DataFrame([new_row])], ignore_index=True)
+    df.to_csv(csv_file, index=False)
+    return dest
+


### PR DESCRIPTION
## Summary
- implement custom CSV-based `CardImageDataset`
- add model checkpoint utilities and helper for adding new card images
- switch model to ResNet18 architecture
- rework training and prediction scripts to use new dataset and model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686866f2f4588333a87aa8cd03b84f60