### PR TITLE
Enable Mac camera via OpenCV API selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ pip install -r requirements.txt
 
 ## Конфигурация камеры
 
-Модуль `card_dealer.camera` предоставляет функцию `capture_image`, снимающую кадр с устройства `0` (обычно `/dev/video0`) в разрешении **1280x720**.
+Модуль `card_dealer.camera` предоставляет функцию `capture_image`, снимающую кадр с устройства `0` (обычно `/dev/video0`) в разрешении **1280x720**. На macOS с чипом M1 можно передать параметр `api_preference=cv2.CAP_AVFOUNDATION`, чтобы задействовать встроенную камеру.
+Функция `stream_frames` использует те же параметры и позволяет получать видео
+для веб‑страницы `/live`.
 
 ## Аппаратная часть
 
@@ -60,9 +62,11 @@ pip install -r requirements.txt
 ```python
 from pathlib import Path
 from card_dealer.camera import capture_image
+import cv2
 from card_dealer.recognizer import recognize_card
 
-img = capture_image(Path("test.png"))
+# Для macOS можно указать api_preference=cv2.CAP_AVFOUNDATION
+img = capture_image(Path("test.png"), api_preference=cv2.CAP_AVFOUNDATION)
 print("Обнаружена карта:", recognize_card(img))
 ```
 
@@ -103,6 +107,10 @@ python -m card_dealer.webapp
 ```
 
 Перейдите на `http://localhost:5000/`, снимите карту, проверьте название и сохраните изображение. При подтверждении фотография попадёт в `dataset/`.
+
+Для просмотра видео с распознаванием в реальном времени откройте страницу
+`http://localhost:5000/live`. На кадрах будет отображаться название найденной
+карты.
 
 ## Обучение нейронной сети
 

--- a/card_dealer/recognizer.py
+++ b/card_dealer/recognizer.py
@@ -115,6 +115,33 @@ def recognize_card(image_path: Path) -> str:
     return best_label
 
 
+def recognize_card_array(image: "np.ndarray") -> str:
+    """Recognize a playing card from an image array."""
+
+    if cv2 is None:
+        raise RuntimeError("OpenCV is required for card recognition")
+
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+
+    templates = _load_templates()
+    if not templates:
+        return "Unknown"
+
+    best_label = "Unknown"
+    best_score = -1.0
+    for label, templ_list in templates.items():
+        for templ in templ_list:
+            if gray.shape[0] < templ.shape[0] or gray.shape[1] < templ.shape[1]:
+                continue
+            result = cv2.matchTemplate(gray, templ, cv2.TM_CCOEFF_NORMED)
+            _min_val, max_val, _min_loc, _max_loc = cv2.minMaxLoc(result)
+            if max_val > best_score:
+                best_score = max_val
+                best_label = label
+
+    return best_label
+
+
 def save_labeled_image(image_path: Path, label: str) -> Path:
     """Save an image with a label into :data:`DATASET_DIR`.
 

--- a/templates/live.html
+++ b/templates/live.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Live Recognition</title>
+  </head>
+  <body>
+    <h1>Live Recognition</h1>
+    <img src="{{ url_for('video_feed') }}" alt="Live feed" style="max-width:100%;height:auto;">
+    <p><a href="{{ url_for('capture') }}">Capture Still</a></p>
+  </body>
+</html>

--- a/tests/test_recognizer.py
+++ b/tests/test_recognizer.py
@@ -24,6 +24,7 @@ class DummyImage:
 class DummyCV2:
     IMREAD_GRAYSCALE = 0
     TM_CCOEFF_NORMED = 1
+    COLOR_BGR2GRAY = 2
 
     def imread(self, path, flag):
         name = Path(path).name
@@ -44,6 +45,9 @@ class DummyCV2:
     def minMaxLoc(self, result):
         val = result[0][0]
         return 0.0, val, (0, 0), (0, 0)
+
+    def cvtColor(self, image, flag):
+        return image
 
 def test_multiple_templates(monkeypatch, tmp_path):
     dataset = tmp_path / "dataset"
@@ -66,4 +70,20 @@ def test_multiple_templates(monkeypatch, tmp_path):
 
     assert result == "Ace of Hearts"
     assert len(templates["Ace of Hearts"]) == 2
+
+
+def test_recognize_card_array(monkeypatch, tmp_path):
+    dataset = tmp_path / "dataset"
+    dataset.mkdir()
+    (dataset / "Ace_of_Hearts.png").write_text("a")
+
+    dummy_cv2 = DummyCV2()
+    monkeypatch.setattr(recognizer, "cv2", dummy_cv2)
+    monkeypatch.setattr(recognizer, "DATASET_DIR", dataset)
+    monkeypatch.setattr(recognizer, "_TEMPLATES", None)
+
+    image = DummyImage("target")
+    result = recognizer.recognize_card_array(image)
+
+    assert result == "Ace of Hearts"
 

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,0 +1,41 @@
+import pytest
+
+try:
+    from card_dealer import webapp
+except ModuleNotFoundError:
+    pytest.skip("Flask not available", allow_module_level=True)
+
+
+def test_video_frames(monkeypatch):
+    frames = ["img1", "img2"]
+
+    def dummy_stream_frames():
+        for f in frames:
+            yield f
+
+    def dummy_recognize(image):
+        return "Ace"
+
+    class DummyCV2:
+        FONT_HERSHEY_SIMPLEX = 0
+
+        def putText(self, frame, text, pos, font, scale, color, thickness):
+            pass
+
+        def imencode(self, ext, frame):
+            return True, DummyBuffer(frame)
+
+    class DummyBuffer:
+        def __init__(self, frame):
+            self.frame = frame
+
+        def tobytes(self):
+            return b"data" + bytes(self.frame, "utf-8")
+
+    monkeypatch.setattr(webapp.camera, "stream_frames", dummy_stream_frames)
+    monkeypatch.setattr(webapp.recognizer, "recognize_card_array", dummy_recognize)
+    monkeypatch.setattr(webapp.camera, "cv2", DummyCV2())
+
+    gen = webapp._video_frames()
+    data = b"".join([next(gen), next(gen)])
+    assert b"data" in data


### PR DESCRIPTION
## Summary
- allow choosing OpenCV backend when capturing images
- show how to activate the macOS camera in documentation
- update camera unit test
- stream camera preview through `/live`
- overlay recognition results on the live video feed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868fa1828d88333b97e7f5afe91b84c