### PR TITLE
Update setup instructions for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ utils.py                # утилиты сохранения модели
 pip install -r requirements.txt
 ```
 
-Основные зависимости: `opencv-python`, `flask`, `numpy`, а также опциональные `RPi.GPIO` и `pyserial` для работы с сервоприводом.
+Основные зависимости: `opencv-python`, `flask`, `numpy`, `torch` и `torchvision`.
+Пакеты `picamera` и `RPi.GPIO` нужны только на Raspberry Pi и
+автоматически пропускаются при установке на macOS и других системах.
 
 ## Конфигурация камеры
 
@@ -54,6 +56,7 @@ pip install -r requirements.txt
 
 1. **GPIO PWM** — укажите номер GPIO‑пина при создании `ServoController`.
 2. **Последовательный порт** — укажите имя порта (например, `/dev/ttyUSB0`).
+   Для этого режима необходим пакет `pyserial`.
 
 ## Запуск примеров
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 flask
 opencv-python
-picamera
 numpy
-RPi.GPIO
 pyserial
 torch
 torchvision
+# Пакеты для Raspberry Pi устанавливаются только на Linux
+picamera; platform_system == "Linux"
+RPi.GPIO; platform_system == "Linux"


### PR DESCRIPTION
## Summary
- clarify optional Raspberry Pi packages and ignore them on non-Linux
- show that macOS installation succeeds and add note about pyserial

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868fedfc5ec83339fece798b3b1926d