### PR TITLE
Add card bounding box display

### DIFF
--- a/card_dealer/camera.py
+++ b/card_dealer/camera.py
@@ -28,12 +28,12 @@ def _apply_settings(cap: Any, settings: Dict[str, Any] | None) -> None:
             cap.set(prop, value)
 
 
-def find_card(frame: Any) -> Any | None:
-    """Найти изображение карты на кадре.
+def find_card_bounds(frame: Any) -> tuple[int, int, int, int] | None:
+    """Найти координаты карты на кадре.
 
-    Алгоритм использует простое пороговое выделение светлой области и
-    возвращает фрагмент изображения, ограниченный минимальным прямоугольником.
-    Если подходящая область не найдена, функция возвращает ``None``.
+    Возвращает кортеж ``(min_x, min_y, max_x, max_y)`` либо ``None`` если
+    подходящая область не найдена. Алгоритм совпадает с тем, что используется
+    в :func:`find_card`.
     """
 
     # Determine image dimensions
@@ -66,6 +66,21 @@ def find_card(frame: Any) -> Any | None:
     if max_x < min_x or max_y < min_y:
         return None
 
+    return min_x, min_y, max_x, max_y
+
+
+def find_card(frame: Any) -> Any | None:
+    """Найти изображение карты на кадре.
+
+    Алгоритм использует простое пороговое выделение светлой области и
+    возвращает фрагмент изображения, ограниченный минимальным прямоугольником.
+    Если подходящая область не найдена, функция возвращает ``None``.
+    """
+    bounds = find_card_bounds(frame)
+    if bounds is None:
+        return None
+
+    min_x, min_y, max_x, max_y = bounds
     try:
         card = frame[min_y : max_y + 1, min_x : max_x + 1]
         if hasattr(card, "copy"):

--- a/card_dealer/webapp.py
+++ b/card_dealer/webapp.py
@@ -82,7 +82,11 @@ def _video_frames():
     for frame in camera.stream_frames():
         if _MIRROR:
             frame = camera.cv2.flip(frame, 1)
-        card = camera.find_card(frame)
+        bounds = camera.find_card_bounds(frame)
+        card = camera.find_card(frame) if bounds is not None else None
+        if bounds is not None:
+            x1, y1, x2, y2 = bounds
+            camera.cv2.rectangle(frame, (x1, y1), (x2, y2), (255, 0, 0), 2)
         source = card if card is not None else frame
         try:
             if _MODEL_PATH is not None:


### PR DESCRIPTION
## Summary
- detect coordinates of card in `find_card_bounds`
- draw bounding box on live video feed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf8fd6db88333889752fe7464adbc