### PR TITLE
Логирование проверки распознавания

### DIFF
--- a/card_dealer/recognizer.py
+++ b/card_dealer/recognizer.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import shutil
+import csv
 from typing import Dict, List
 
 try:  # pragma: no cover - OpenCV/Numpy may not be installed
@@ -183,5 +184,41 @@ def save_labeled_image(image_path: Path, label: str) -> Path:
     # immediately and multiple templates per label are reloaded correctly
     global _TEMPLATES
     _TEMPLATES = None
+    return dest
+
+
+def log_verification(filename: str, predicted: str, actual: str) -> None:
+    """Append a verification record to ``verify_log.csv`` in :data:`DATASET_DIR`."""
+
+    log_path = DATASET_DIR / "verify_log.csv"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    new_file = not log_path.exists()
+    with log_path.open("a", newline="") as f:
+        writer = csv.writer(f)
+        if new_file:
+            writer.writerow(["file", "predicted", "actual"])
+        writer.writerow([filename, predicted, actual])
+
+
+def record_verification(image_path: Path, predicted: str, actual: str) -> Path:
+    """Save the verified image and log the prediction result.
+
+    Parameters
+    ----------
+    image_path:
+        Temporary path of the image being verified.
+    predicted:
+        Label predicted by the recognizer.
+    actual:
+        Label provided by the user as the correct one.
+
+    Returns
+    -------
+    Path
+        Destination of the saved image inside :data:`DATASET_DIR`.
+    """
+
+    dest = save_labeled_image(image_path, actual)
+    log_verification(dest.name, predicted, actual)
     return dest
 

--- a/card_dealer/webapp.py
+++ b/card_dealer/webapp.py
@@ -21,6 +21,8 @@ app = Flask(__name__, template_folder=str(TEMPLATE_DIR))
 
 # Temporary capture filename inside dataset directory
 _CAPTURE_NAME = "_capture.png"
+# Temporary filename for uploaded verification images
+_UPLOAD_NAME = "_upload.png"
 # Path to a CNN model used for live recognition; None means template recognizer
 _MODEL_PATH: Path | None = None
 # Latest label recognized in the video stream
@@ -67,6 +69,7 @@ def capture() -> str:
         "confirm.html",
         image_name=_CAPTURE_NAME,
         prediction=prediction,
+        back_url=url_for("capture"),
     )
 
 
@@ -74,6 +77,26 @@ def capture() -> str:
 def dataset_file(filename: str):
     """Serve files from the dataset directory."""
     return send_from_directory(recognizer.DATASET_DIR, filename)
+
+
+@app.route("/verify", methods=["GET", "POST"])
+def verify_upload() -> str:
+    """Upload an image for recognition verification."""
+    if request.method == "POST":
+        file = request.files.get("image")
+        if file:
+            image_path = recognizer.DATASET_DIR / _UPLOAD_NAME
+            image_path.parent.mkdir(parents=True, exist_ok=True)
+            file.save(str(image_path))
+            prediction = recognizer.recognize_card(image_path)
+            return render_template(
+                "confirm.html",
+                image_name=_UPLOAD_NAME,
+                prediction=prediction,
+                back_url=url_for("verify_upload"),
+            )
+        return redirect(url_for("verify_upload"))
+    return render_template("upload.html")
 
 
 def _video_frames():
@@ -157,10 +180,10 @@ def current_card() -> dict[str, str | None]:
 @app.route("/confirm", methods=["POST"])
 def confirm() -> str:
     """Save the labeled image provided by the user."""
-    label = request.form.get("label", "").strip()
+    label = request.form.get("label", "").strip() or "Unknown"
+    predicted = request.form.get("prediction", "").strip() or label
     image_path = recognizer.DATASET_DIR / request.form.get("image_name", _CAPTURE_NAME)
-    if label:
-        recognizer.save_labeled_image(image_path, label)
+    dest = recognizer.record_verification(image_path, predicted, label)
     if image_path.exists():
         image_path.unlink()
     return redirect(url_for("next_card"))

--- a/templates/confirm.html
+++ b/templates/confirm.html
@@ -10,10 +10,11 @@
     <p>Predicted label: {{ prediction }}</p>
     <form action="{{ url_for('confirm') }}" method="post">
       <input type="hidden" name="image_name" value="{{ image_name }}">
+      <input type="hidden" name="prediction" value="{{ prediction }}">
       <label for="label">Correct label:</label>
       <input id="label" name="label" type="text" value="{{ prediction }}">
       <button type="submit">Save</button>
     </form>
-    <p><a href="{{ url_for('capture') }}">Retake</a></p>
+    <p><a href="{{ back_url }}">Retake</a></p>
   </body>
 </html>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Verify Card</title>
+  </head>
+  <body>
+    <h1>Upload Card Image</h1>
+    <form action="{{ url_for('verify_upload') }}" method="post" enctype="multipart/form-data">
+      <input type="file" name="image" accept="image/*">
+      <button type="submit">Upload</button>
+    </form>
+  </body>
+</html>

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,3 +1,4 @@
+import io
 import pytest
 from pathlib import Path
 
@@ -130,3 +131,46 @@ def test_video_frames_mirror(monkeypatch):
     gen = webapp._video_frames()
     next(gen)
     assert calls["flip"] == ("img", 1)
+
+
+def test_verify_upload(monkeypatch, tmp_path):
+    monkeypatch.setattr(webapp.recognizer, "DATASET_DIR", tmp_path / "ds")
+
+    def dummy_recognize(path):
+        assert path.name == webapp._UPLOAD_NAME
+        return "Queen"
+
+    monkeypatch.setattr(webapp.recognizer, "recognize_card", dummy_recognize)
+
+    client = webapp.app.test_client()
+    data = {"image": (io.BytesIO(b"img"), "card.png")}
+    resp = client.post("/verify", data=data, content_type="multipart/form-data")
+
+    assert resp.status_code == 200
+    assert b"Queen" in resp.data
+    assert (tmp_path / "ds" / webapp._UPLOAD_NAME).exists()
+
+
+def test_confirm_logs_result(monkeypatch, tmp_path):
+    ds = tmp_path / "ds"
+    monkeypatch.setattr(webapp.recognizer, "DATASET_DIR", ds)
+    ds.mkdir(parents=True, exist_ok=True)
+
+    tmp_img = ds / webapp._UPLOAD_NAME
+    tmp_img.write_text("img")
+
+    client = webapp.app.test_client()
+    data = {
+        "image_name": webapp._UPLOAD_NAME,
+        "label": "Ace",
+        "prediction": "King",
+    }
+    resp = client.post("/confirm", data=data)
+
+    assert resp.status_code == 302
+    saved = ds / "Ace.png"
+    assert saved.exists()
+    log_path = ds / "verify_log.csv"
+    assert log_path.exists()
+    rows = log_path.read_text().splitlines()
+    assert rows[1].split(",") == [saved.name, "King", "Ace"]


### PR DESCRIPTION
## Summary
- добавлена функция `record_verification` для одновременного сохранения изображения и записи в журнал
- маршрут `/confirm` теперь использует новую функцию

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686cfba39e10833393772ce56072f039