### PR TITLE
Добавлен список карт для подтверждения

### DIFF
--- a/card_dealer/webapp.py
+++ b/card_dealer/webapp.py
@@ -15,6 +15,25 @@ from flask import (
 from . import camera, recognizer
 import predict
 
+# List of all standard playing cards used for manual labeling
+_RANKS = [
+    "Ace",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+    "10",
+    "Jack",
+    "Queen",
+    "King",
+]
+_SUITS = ["Hearts", "Diamonds", "Clubs", "Spades"]
+CARD_NAMES = [f"{rank} of {suit}" for suit in _SUITS for rank in _RANKS]
+
 ROOT_DIR = Path(__file__).resolve().parent.parent
 TEMPLATE_DIR = ROOT_DIR / "templates"
 app = Flask(__name__, template_folder=str(TEMPLATE_DIR))
@@ -69,6 +88,7 @@ def capture() -> str:
         "confirm.html",
         image_name=_CAPTURE_NAME,
         prediction=prediction,
+        card_names=CARD_NAMES,
         back_url=url_for("capture"),
     )
 
@@ -93,6 +113,7 @@ def verify_upload() -> str:
                 "confirm.html",
                 image_name=_UPLOAD_NAME,
                 prediction=prediction,
+                card_names=CARD_NAMES,
                 back_url=url_for("verify_upload"),
             )
         return redirect(url_for("verify_upload"))

--- a/templates/confirm.html
+++ b/templates/confirm.html
@@ -12,7 +12,11 @@
       <input type="hidden" name="image_name" value="{{ image_name }}">
       <input type="hidden" name="prediction" value="{{ prediction }}">
       <label for="label">Correct label:</label>
-      <input id="label" name="label" type="text" value="{{ prediction }}">
+      <select id="label" name="label">
+        {% for name in card_names %}
+        <option value="{{ name }}" {% if name == prediction %}selected{% endif %}>{{ name }}</option>
+        {% endfor %}
+      </select>
       <button type="submit">Save</button>
     </form>
     <p><a href="{{ back_url }}">Retake</a></p>


### PR DESCRIPTION
## Изменения
- сформирован полный список названий карт в `webapp.py`
- страница подтверждения теперь показывает выпадающий список вместо текстового поля
- маршруты захвата и загрузки передают этот список в шаблон
- обновлены тесты (прогон без изменений)

## Тесты
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d01b4f9008333af8809c24c71aa25