### PR TITLE
Fix label 'upload' issue on verify

### DIFF
--- a/card_dealer/recognizer.py
+++ b/card_dealer/recognizer.py
@@ -59,6 +59,9 @@ def _load_templates() -> Dict[str, List["np.ndarray"]]:
         for img_path in DATASET_DIR.iterdir():
             if not img_path.is_file():
                 continue
+            if img_path.name.startswith("_"):
+                # Temporary files like _upload.png should not be used as templates
+                continue
             stem = img_path.stem
             base = stem.rsplit("_", 1)[0] if stem.rsplit("_", 1)[-1].isdigit() else stem
             label = base.replace("_", " ")

--- a/card_dealer/webapp.py
+++ b/card_dealer/webapp.py
@@ -108,7 +108,11 @@ def verify_upload() -> str:
             image_path = recognizer.DATASET_DIR / _UPLOAD_NAME
             image_path.parent.mkdir(parents=True, exist_ok=True)
             file.save(str(image_path))
-            prediction = recognizer.recognize_card(image_path)
+            if _MODEL_PATH is not None:
+                result = predict.recognize_card(image_path, model_path=str(_MODEL_PATH))
+                prediction = result.get("label", "Unknown")
+            else:
+                prediction = recognizer.recognize_card(image_path)
             return render_template(
                 "confirm.html",
                 image_name=_UPLOAD_NAME,


### PR DESCRIPTION
## Summary
- ignore temporary files starting with `_` when loading recognition templates
- use CNN model for /verify when selected
- test verifying with model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d060a49688333a0a6a44d8ee5d53d