### PR TITLE
Исправления датасета и выводов в Streamlit

### DIFF
--- a/convert_dataset_to_yolo.py
+++ b/convert_dataset_to_yolo.py
@@ -9,10 +9,20 @@ import shutil
 import pandas as pd
 
 
+def _map_split(name: str) -> str:
+    """Map dataset split names to YOLO conventions."""
+    name = name.strip().lower()
+    if name in {"valid", "validation"}:
+        return "val"
+    return name
+
+
 def convert(csv_path: Path, output_root: Path) -> None:
+    """Convert classification CSV to YOLOv8 dataset structure."""
     df = pd.read_csv(csv_path)
-    for split in {"train", "valid", "test"}:
-        subset = df[df["data set"] == split]
+    splits = {_map_split(s) for s in df["data set"].dropna().unique()}
+    for split in splits:
+        subset = df[df["data set"].str.strip().str.lower().map(_map_split) == split]
         if subset.empty:
             continue
         img_dir = output_root / "images" / split

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -55,15 +55,25 @@ def main() -> None:
         file_bytes = np.asarray(bytearray(uploaded.read()), dtype=np.uint8)
         img = cv2.imdecode(file_bytes, 1)
         boxes = detector.detect(img)
+        detected_labels: List[str] = []
         if classifier:
-            labels = []
             for x1, y1, x2, y2 in boxes:
                 roi = img[y1:y2, x1:x2]
                 label = classifier.predict(roi)
-                labels.append(label)
-                cv2.putText(img, label, (x1, y1 - 5), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (255, 0, 0), 1)
+                detected_labels.append(label)
+                cv2.putText(
+                    img,
+                    label,
+                    (x1, y1 - 5),
+                    cv2.FONT_HERSHEY_SIMPLEX,
+                    0.5,
+                    (255, 0, 0),
+                    1,
+                )
         img = draw_boxes(img, boxes)
         st.image(img, channels="BGR")
+        if detected_labels:
+            st.write("Обнаруженные карты: " + ", ".join(detected_labels))
 
 
 if __name__ == "__main__":  # pragma: no cover - скрипт


### PR DESCRIPTION
## Summary
- улучшена конвертация датасета в формат YOLO
- в демо на Streamlit отображаются названия распознанных карт

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d3c2d55d48333a944db59285495b9