### PR TITLE
Добавлена сортировка карт по рубашке

### DIFF
--- a/card_dealer/__init__.py
+++ b/card_dealer/__init__.py
@@ -1,1 +1,5 @@
-"""Placeholder module."""
+"""Утилиты для работы с игральными картами."""
+
+from .sorter import is_card_back, sort_by_back
+
+__all__ = ["is_card_back", "sort_by_back"]

--- a/card_dealer/sorter.py
+++ b/card_dealer/sorter.py
@@ -1,0 +1,91 @@
+"""Функции для сортировки карт по ориентации."""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    import numpy as np
+except ModuleNotFoundError:  # pragma: no cover - numpy optional
+    np = None  # type: ignore
+
+from .servo_controller import ServoController
+
+
+_THRESHOLD = 40
+
+
+def is_card_back(image: Any) -> bool:
+    """Определить, является ли карта рубашкой.
+
+    Функция оценивает разброс яркости по изображению. Если разброс
+    меньше порога, предполагается, что на изображении рубашка карты.
+    Поддерживаются объекты ``numpy.ndarray`` и вложенные списки,
+    содержащие значения пикселей.
+    """
+
+    if np is not None and hasattr(image, "shape"):
+        arr = image
+        if arr.ndim == 3:
+            arr = arr.mean(axis=2)
+        return float(arr.max() - arr.min()) < _THRESHOLD
+
+    # Обработка списков без использования numpy
+    values = []
+    try:
+        height = len(image)
+        width = len(image[0]) if height else 0
+    except Exception:
+        return False
+
+    for y in range(height):
+        for x in range(width):
+            pixel = image[y][x]
+            try:
+                value = sum(pixel) / len(pixel)
+            except TypeError:
+                value = pixel
+            values.append(value)
+
+    if not values:
+        return False
+    return max(values) - min(values) < _THRESHOLD
+
+
+def sort_by_back(
+    image: Any,
+    servo_main: ServoController,
+    servo_sort: ServoController,
+    *,
+    back_angle: float = 30,
+    face_angle: float = 0,
+    deal_angle: float = 90,
+) -> bool:
+    """Отправить карту в нужную стопку в зависимости от ориентации.
+
+    Параметры
+    ---------
+    image:
+        Образ карты в формате ``numpy.ndarray`` или вложенных списков.
+    servo_main:
+        Контроллер основного сервопривода, выдающего карту.
+    servo_sort:
+        Контроллер сервопривода, отклоняющего карту в стопку.
+    back_angle:
+        Угол отклонения для карт рубашкой вверх.
+    face_angle:
+        Угол отклонения для обычных карт.
+    deal_angle:
+        Угол срабатывания основного сервопривода.
+
+    Возвращает
+    ---------
+    bool
+        ``True``, если обнаружена рубашка, иначе ``False``.
+    """
+
+    back = is_card_back(image)
+    angle = back_angle if back else face_angle
+    servo_sort.dispense_card(angle=angle)
+    servo_main.dispense_card(angle=deal_angle)
+    return back

--- a/tests/test_sorter.py
+++ b/tests/test_sorter.py
@@ -1,0 +1,38 @@
+from card_dealer.sorter import is_card_back, sort_by_back
+from card_dealer.servo_controller import ServoController, _HardwareInterface
+
+
+class DummyDriver(_HardwareInterface):
+    def __init__(self):
+        self.angles = []
+
+    def dispense(self, angle: float = 90) -> None:  # pragma: no cover - simple
+        self.angles.append(angle)
+
+
+def test_is_card_back():
+    back_img = [[[10 for _ in range(3)] for _ in range(5)] for _ in range(5)]
+    face_img = [[[10 for _ in range(3)] for _ in range(5)] for _ in range(5)]
+    face_img[2][2] = [200, 200, 200]
+
+    assert is_card_back(back_img)
+    assert not is_card_back(face_img)
+
+
+def test_sort_by_back():
+    driver_main = DummyDriver()
+    driver_sort = DummyDriver()
+    servo_main = ServoController(driver=driver_main)
+    servo_sort = ServoController(driver=driver_sort)
+
+    back_img = [[[0 for _ in range(3)] for _ in range(4)] for _ in range(4)]
+    face_img = [[[0 for _ in range(3)] for _ in range(4)] for _ in range(4)]
+    face_img[0][0] = [255, 255, 255]
+
+    sort_by_back(back_img, servo_main, servo_sort, back_angle=30, face_angle=0, deal_angle=45)
+    assert driver_sort.angles[-1] == 30
+    assert driver_main.angles[-1] == 45
+
+    sort_by_back(face_img, servo_main, servo_sort, back_angle=30, face_angle=0, deal_angle=45)
+    assert driver_sort.angles[-1] == 0
+    assert driver_main.angles[-1] == 45


### PR DESCRIPTION
## Summary
- add card orientation sorter and export in package
- cover new functionality with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e121b13608333a3f49cfd0dcfd3ba