### PR TITLE
Refactor card orientation logic

### DIFF
--- a/tests/test_sorter.py
+++ b/tests/test_sorter.py
@@ -1,38 +1,27 @@
 from card_dealer.sorter import is_card_back, sort_by_back
-from card_dealer.servo_controller import ServoController, _HardwareInterface
 
 
-class DummyDriver(_HardwareInterface):
-    def __init__(self):
-        self.angles = []
-
-    def dispense(self, angle: float = 90) -> None:  # pragma: no cover - simple
-        self.angles.append(angle)
+def _dummy_classifier(img):
+    return all(ch == 0 for ch in img[0][0])
 
 
 def test_is_card_back():
-    back_img = [[[10 for _ in range(3)] for _ in range(5)] for _ in range(5)]
-    face_img = [[[10 for _ in range(3)] for _ in range(5)] for _ in range(5)]
-    face_img[2][2] = [200, 200, 200]
+    back_img = [[[0 for _ in range(3)] for _ in range(5)] for _ in range(5)]
+    face_img = [[[0 for _ in range(3)] for _ in range(5)] for _ in range(5)]
+    face_img[0][0] = [1, 1, 1]
 
-    assert is_card_back(back_img)
-    assert not is_card_back(face_img)
+    assert is_card_back(back_img, classifier=_dummy_classifier)
+    assert not is_card_back(face_img, classifier=_dummy_classifier)
 
 
 def test_sort_by_back():
-    driver_main = DummyDriver()
-    driver_sort = DummyDriver()
-    servo_main = ServoController(driver=driver_main)
-    servo_sort = ServoController(driver=driver_sort)
-
     back_img = [[[0 for _ in range(3)] for _ in range(4)] for _ in range(4)]
     face_img = [[[0 for _ in range(3)] for _ in range(4)] for _ in range(4)]
     face_img[0][0] = [255, 255, 255]
 
-    sort_by_back(back_img, servo_main, servo_sort, back_angle=30, face_angle=0, deal_angle=45)
-    assert driver_sort.angles[-1] == 30
-    assert driver_main.angles[-1] == 45
-
-    sort_by_back(face_img, servo_main, servo_sort, back_angle=30, face_angle=0, deal_angle=45)
-    assert driver_sort.angles[-1] == 0
-    assert driver_main.angles[-1] == 45
+    groups = sort_by_back([
+        (back_img, is_card_back(back_img, classifier=_dummy_classifier)),
+        (face_img, is_card_back(face_img, classifier=_dummy_classifier)),
+    ])
+    assert groups["back"] == [back_img]
+    assert groups["face"] == [face_img]


### PR DESCRIPTION
## Summary
- remove pixel heuristics from `is_card_back`
- delegate back/face detection to an external classifier
- update tests to use a dummy classifier

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e17746a108333b36c90da22ed3740