### PR TITLE
Add deck filtering and new emulator modes

### DIFF
--- a/card_dealer/__init__.py
+++ b/card_dealer/__init__.py
@@ -1,5 +1,13 @@
 """Утилиты для работы с игральными картами."""
 
 from .sorter import is_card_back, sort_by_back
+from .deck import count_cards, deduplicate, exclude_cards, find_missing_cards
 
-__all__ = ["is_card_back", "sort_by_back"]
+__all__ = [
+    "is_card_back",
+    "sort_by_back",
+    "deduplicate",
+    "exclude_cards",
+    "count_cards",
+    "find_missing_cards",
+]

--- a/card_dealer/deck.py
+++ b/card_dealer/deck.py
@@ -1,0 +1,43 @@
+"""Утилиты для работы с колодой карт."""
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from .cards import CardClasses
+
+
+def deduplicate(items: Iterable[str]) -> list[str]:
+    """Вернуть список без дубликатов с сохранением порядка."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+def exclude_cards(deck: Iterable[str], to_remove: Iterable[str]) -> tuple[list[str], list[str]]:
+    """Разделить колоду на исключённые и оставшиеся карты."""
+    remove_set = set(to_remove)
+    excluded: list[str] = []
+    remaining: list[str] = []
+    for card in deck:
+        if card in remove_set:
+            excluded.append(card)
+        else:
+            remaining.append(card)
+    return excluded, remaining
+
+
+def count_cards(deck: Iterable[str]) -> int:
+    """Вернуть количество карт в колоде."""
+    return len(list(deck))
+
+
+def find_missing_cards(
+    deck: Iterable[str], *, full_deck: Sequence[str] | None = None
+) -> list[str]:
+    """Найти недостающие карты относительно полной колоды."""
+    full = set(full_deck or CardClasses.LABELS)
+    return sorted(full - set(deck))

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -1,0 +1,30 @@
+from card_dealer.deck import (
+    deduplicate,
+    exclude_cards,
+    count_cards,
+    find_missing_cards,
+)
+from card_dealer.cards import CardClasses
+
+
+def test_deduplicate_preserves_order():
+    seq = ["A", "B", "A", "C", "B"]
+    assert deduplicate(seq) == ["A", "B", "C"]
+
+
+def test_exclude_cards():
+    deck = ["Ace", "Two", "Three"]
+    excl, rest = exclude_cards(deck, ["Two"])
+    assert excl == ["Two"]
+    assert rest == ["Ace", "Three"]
+
+
+def test_count_cards():
+    deck = ["a", "b", "c"]
+    assert count_cards(deck) == 3
+
+
+def test_find_missing_cards():
+    deck = CardClasses.LABELS[:-1]
+    missing = find_missing_cards(deck)
+    assert missing == [CardClasses.LABELS[-1]]


### PR DESCRIPTION
## Summary
- allow excluding cards while sorting
- show removed cards and remaining deck
- add modes for counting cards and detecting missing cards
- extend main menu with new options

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687015bd561483338f504f44d2db114a