### PR TITLE
Fix loading of models with simpler heads

### DIFF
--- a/model.py
+++ b/model.py
@@ -7,15 +7,18 @@ from torchvision.models import resnet18
 IMAGE_SIZE = (224, 224)
 
 
-def create_model(num_classes: int) -> nn.Module:
-    """Вернуть модель ResNet18 с расширенной классификационной головой."""
+def create_model(num_classes: int, *, simple_head: bool = False) -> nn.Module:
+    """Return ResNet18 with a classification head."""
     model = resnet18(weights=None)
     in_features = model.fc.in_features
-    model.fc = nn.Sequential(
-        nn.Linear(in_features, 512),
-        nn.ReLU(inplace=True),
-        nn.Dropout(0.2),
-        nn.Linear(512, num_classes),
-    )
+    if simple_head:
+        model.fc = nn.Linear(in_features, num_classes)
+    else:
+        model.fc = nn.Sequential(
+            nn.Linear(in_features, 512),
+            nn.ReLU(inplace=True),
+            nn.Dropout(0.2),
+            nn.Linear(512, num_classes),
+        )
     return model
 

--- a/predict.py
+++ b/predict.py
@@ -63,7 +63,11 @@ def _load_model(model_path: str, device: str) -> tuple[torch.nn.Module, dict[int
     else:
         idx_to_class = {i: f"class_{i}" for i in range(num_classes)}
 
-    model = create_model(num_classes=num_classes)
+    # Determine the type of classification head expected by the state dict
+    state_keys = set(state.keys())
+    simple_head = "fc.weight" in state_keys and not any(k.startswith("fc.0") for k in state_keys)
+
+    model = create_model(num_classes=num_classes, simple_head=simple_head)
     model.load_state_dict(state, strict=False)
     model.to(device)
     model.eval()


### PR DESCRIPTION
## Summary
- support loading checkpoints that use a single linear layer as the classifier head
- detect the required head type in `predict._load_model`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687027aef9b48333a86c7c69810aab9b